### PR TITLE
Speed up tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# NWBSD
+
+To install dependencies:
+
+```
+	pip install -r requirements.txt
+	pip install -r requirements-dev.txt
+```
+
+To install the package:
+
+```
+	pip install -e .
+```
+
+To run the tests:
+
+```
+	tox
+```

--- a/download_data.sh
+++ b/download_data.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if ! [ -f tests/570014520.nwb ]; then
+  curl -o tests/570014520.nwb "https://data.kitware.com/api/v1/file/5a4f91618d777f5e872f8101/download"
+fi

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
+pytest-xdist
 tox

--- a/tests/test_nwbsd.py
+++ b/tests/test_nwbsd.py
@@ -5,16 +5,14 @@ import pytest
 import os
 
 
-@pytest.fixture(scope="module")
-def nwbSd():
-    path = os.path.dirname(os.path.realpath(__file__))
-    testFile = '570014520.nwb'
-    return NwbSd(os.path.join(path, testFile))
-
-
 def _compareLists(list1, list2):
     assert len(list1) == len(list2)
     assert sorted(list1) == sorted(list2)
+
+
+@pytest.fixture(scope="module")
+def nwbSd():
+    return NwbSd(os.path.join('tests', '570014520.nwb'))
 
 
 def test_nwbsd_constructor(nwbSd):

--- a/tests/test_nwbsd.py
+++ b/tests/test_nwbsd.py
@@ -5,7 +5,7 @@ import pytest
 import os
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def nwbSd():
     path = os.path.dirname(os.path.realpath(__file__))
     testFile = '570014520.nwb'

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ deps =
     -rrequirements-dev.txt
     -rrequirements.txt
 
-commands = pytest
+commands = pytest -n 4

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,6 @@ deps =
     -rrequirements-dev.txt
     -rrequirements.txt
 
-commands = pytest -n 4
+commands =
+    ./download_data.sh
+    pytest -n 4


### PR DESCRIPTION
Fixes #3.

Make the tests run in parallel and add a download script for the test nwb file. 